### PR TITLE
Add templates for main and view

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -69,7 +69,7 @@ ROOT_URLCONF = "config.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "config" / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [

--- a/config/templates/base.html
+++ b/config/templates/base.html
@@ -1,0 +1,25 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>Cost splitter</title>
+    <link rel="stylesheet" href="{% static 'css/style.css' %}">
+    <script src="{% static 'scripts/top.js' %}"></script>
+</head>
+
+<body>
+    <div class="links-container">
+        <a href="{% url 'cost_splitter:list_report' %}">Start</a>
+        <a href="{% url 'cost_splitter:add_cost' %}">Add cost</a>
+        <a href="{% url 'cost_splitter:add_report' %}">Create split</a>
+        <a href="{% url 'cost_splitter:list_cost' %}">All costs</a><br>
+    </div>
+    <div class="main">
+        {% block content %}{% endblock content %}
+    </div>
+    <!-- <button onclick="myFunction()">Click me!</button> -->
+    <script src="{% static 'scripts/bottom.js' %}"></script>
+</body>
+
+</html>

--- a/config/templates/main.html
+++ b/config/templates/main.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<h1>All available apps:</h1>
+<ul>
+    <li><a href="{% url 'cost_splitter:list_report' %}">Cost splitter</a></li>
+</ul>
+
+
+{% endblock content %}

--- a/config/urls.py
+++ b/config/urls.py
@@ -17,8 +17,11 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import include, path
 
+from .views import MainApplicationView
+
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("cost_splitter/", include(("apps.cost_splitter.urls", "cost_splitter"))),
+    path("cost_splitter/", include(("apps.cost_splitter.urls", "cost_splitter")), name="template2"),
+    path("", MainApplicationView.as_view(), name="main"),
 ]

--- a/config/views.py
+++ b/config/views.py
@@ -1,0 +1,19 @@
+from typing import Any
+
+from django.views.generic.base import TemplateView
+
+
+class MainApplicationView(TemplateView):
+    """View to display a list of all CostSplitReports."""
+
+    template_name = "main.html"
+
+    def get_context_data(self, **kwargs: Any):
+        """Adds 'reports' to the context.
+
+        Intention is to have a list of apps with entry points, even if the url works, it doesn't work in a
+        loop with variables for some reason.
+        """
+        context = super().get_context_data(**kwargs)
+        context["registrered_apps"] = {"cost_splitter": "list_report"}
+        return context


### PR DESCRIPTION
This pull request adds templates for the main application and view. It includes changes to the `TEMPLATES` setting in the `settings.py` file, as well as the addition of two new HTML templates: `main.html` and `view.html`. The `main.html` template includes links to different parts of the application, while the `view.html` template displays a list of all available apps. Additionally, a new view class `MainApplicationView` is added to handle the rendering of the `main.html` template.